### PR TITLE
Fixed bug

### DIFF
--- a/pkg/controller/baremetalasset/baremetalasset_controller.go
+++ b/pkg/controller/baremetalasset/baremetalasset_controller.go
@@ -393,6 +393,7 @@ func (r *ReconcileBareMetalAsset) ensureHiveSyncSet(instance *midasv1alpha1.Bare
 				Reason:  "SyncSetCreated",
 				Message: "SyncSet created successfully",
 			})
+			return nil
 		}
 		// other error. fail reconcile
 		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MGMT-533

Fixes a bug in `baremetalasset_controller.ensureHiveSyncSet()` where Status as 'True' is incorrectly overwritten with Status as 'False'